### PR TITLE
Fix Vue Diagram link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # How to Add and Customize Annotations in Nodes and Connectors in Vue Diagram
 
-A quick start Vue project that shows how to add annotations to nodes and connectors in the Syncfusion&reg; [Vue Diagram](https://www.syncfusion.com/vue-components/vue-diagram?utm_source=github&utm_medium=listing&utm_campaign=vue-diagram-annotations-sample) component. This project includes code snippets to add an annotation programmatically and showing customization options like horizontal alignment, vertical alignment, offset, text wrapping, and font styles. It includes code snippets for interacting with annotations and adding hyperlinks to them.
+A quick start Vue project that shows how to add annotations to nodes and connectors in the [Vue Diagram](https://www.syncfusion.com/vue-components/vue-diagram) component. This project includes code snippets to add an annotation programmatically and showing customization options like horizontal alignment, vertical alignment, offset, text wrapping, and font styles. It includes code snippets for interacting with annotations and adding hyperlinks to them.
 
 Watch the video: https://www.syncfusion.com/tutorial-videos/vue/diagram?title=how-to-add-and-customize-annotations-in-nodes-and-connectors 
 


### PR DESCRIPTION
Removed the '&reg;' HTML entity from the Vue Diagram link in the README.